### PR TITLE
added support: php, haml, pug (previously jade), slim, less, stylus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.idea/*
+.idea/
+.gradle/
 
 *.iws
 *.iml

--- a/src/main/java/QuickSwitchAction.java
+++ b/src/main/java/QuickSwitchAction.java
@@ -13,7 +13,11 @@ public class QuickSwitchAction extends AnAction {
 
     private AnActionEvent latestEvent;
 
-    private List<String> extensions = Arrays.asList("ts", "js", "html", "css", "sass", "scss");
+    private List<String> extensions = Arrays.asList(
+      "ts", "js",
+      "html", "php", "haml", "jade", "pug", "slim",
+      "css", "sass", "scss", "less", "styl"
+    );
 
     public QuickSwitchAction() {
         super("QuickSwitch");


### PR DESCRIPTION
Since there are many other CSS preprocessors supported by Angular 6 and possibly some HTML preprocessors used by businesses, I added what I believe to be the rest of the supported CSS preprocessor- and a couple HTML preprocessor filetypes. In addition, I added PHP support because there are CSS preprocessors built on top of PHP such as CSS Crush and who knows, maybe a business or two wants to do some crazy PHP/Angular combinations.